### PR TITLE
Make GXGoogleMaps package open source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Package.resolved
+.swiftpm/xcode/package.xcworkspace/xcuserdata
+.swiftpm/xcode/xcuserdata

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [GeneXus S.A.]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Package.swift
+++ b/Package.swift
@@ -12,44 +12,36 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/googlemaps/ios-maps-sdk.git", .upToNextMajor(from: "9.0.0")),
-		.package(url: "https://github.com/googlemaps/google-maps-ios-utils.git", .upToNextMajor(from: "6.0.0"))
-	] + Package.Dependency.gxFrameworks(remotePackageUrls: [
-		"https://github.com/GeneXus-SwiftPackages/GXCoreUI.git",
-		"https://github.com/GeneXus-SwiftPackages/GXCoreModule_Common_Maps.git",
-		"https://github.com/GeneXus-SwiftPackages/GXUCMaps.git",
-	]),
+		.package(url: "https://github.com/googlemaps/google-maps-ios-utils.git", .upToNextMajor(from: "6.0.0")),
+		.gxFramework("GXCoreUI"),
+		.gxFramework("GXCoreModule_Common_Maps"),
+		.gxFramework("GXUCMaps"),
+	],
 	targets: [
 		.target(name: "GXGoogleMaps",
 				dependencies: [
 					.product(name: "GoogleMaps", package: "ios-maps-sdk"),
 					.product(name: "GoogleMapsUtils", package: "google-maps-ios-utils"),
-					.gxFrameworkProduct(name: "GXCoreUI", remotePackage: "GXCoreUI"),
-					.gxFrameworkProduct(name: "GXCoreModule_Common_Maps", remotePackage: "GXCoreModule_Common_Maps"),
-					.gxFrameworkProduct(name: "GXUCMaps", remotePackage: "GXUCMaps"),
+					.product(name: "GXCoreUI", package: "GXCoreUI"),
+					.product(name: "GXCoreModule_Common_Maps", package: "GXCoreModule_Common_Maps"),
+					.product(name: "GXUCMaps", package: "GXUCMaps"),
 				]),
 	]
 )
 
 extension Package.Dependency {
-	static func gxFrameworks(remotePackageUrls: [String]) -> [Package.Dependency] {
-		if let localPath = gxFrameworksLocalPath() {
-			return [ .package(name: "GXFrameworksLocal", path: localPath) ]
+	static func gxFramework(_ name: String) -> Package.Dependency {
+		guard let localPath = gxFrameworksLocalPath() else {
+			return .package(url: "https://github.com/GeneXus-SwiftPackages/\(name).git", .upToNextMajor(from: GX_FC_LAST_VERSION))
 		}
-		return remotePackageUrls.map {
-			.package(url: $0, .upToNextMajor(from: GX_FC_LAST_VERSION))
-		}
+		return .package(name: name, path: localPath.appending(component: name).path)
 	}
 }
 
-extension Target.Dependency {
-	static func gxFrameworkProduct(name: String, remotePackage: String) -> Self {
-		.product(name: name, package: gxFrameworksLocalPath() != nil ? "GXFrameworksLocal" : remotePackage)
-	}
-}
-
-func gxFrameworksLocalPath() -> String? {
+func gxFrameworksLocalPath() -> URL? {
 	guard let pathCString = getenv("GX_FRAMEWORKS_LOCAL_PATH") else {
 		return nil
 	}
-	return String(cString: pathCString)
+	let path = String(cString: pathCString)
+	return URL(filePath: path)
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,32 +1,29 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 import PackageDescription
+
+let GX_FC_LAST_VERSION = Version("3.2.0-beta")
 
 let package = Package(
 	name: "GXGoogleMaps",
-	platforms: [.iOS("12.0")],
+	platforms: [.iOS(.v15), .tvOS("18.0"), .watchOS(.v10), .visionOS("2.0")],
 	products: [
-		.library(
-			name: "GXGoogleMaps",
-			targets: ["GXGoogleMapsWrapper"])
+		.library(name: "GXGoogleMaps", targets: ["GXGoogleMaps"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreModule_Common_Maps.git", exact: "1.1.0"),
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreUI.git", exact: "1.1.0"),
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXUCMaps.git", exact: "1.1.0")
+		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreUI.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
+		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreModule_Common_Maps.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
+		.package(url: "https://github.com/GeneXus-SwiftPackages/GXUCMaps.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
+		.package(url: "https://github.com/googlemaps/ios-maps-sdk.git", .upToNextMajor(from: "9.0.0")),
+		.package(url: "https://github.com/googlemaps/google-maps-ios-utils.git", .upToNextMajor(from: "6.0.0"))
 	],
 	targets: [
-		.target(name: "GXGoogleMapsWrapper",
+		.target(name: "GXGoogleMaps",
 				dependencies: [
-					"GXGoogleMaps",
-					.product(name: "GXCoreModule_Common_Maps", package: "GXCoreModule_Common_Maps", condition: .when(platforms: [.iOS])),
-					.product(name: "GXCoreUI", package: "GXCoreUI", condition: .when(platforms: [.iOS])),
-					.product(name: "GXUCMaps", package: "GXUCMaps", condition: .when(platforms: [.iOS]))
-				],
-				path: "Sources"),
-		.binaryTarget(
-			name: "GXGoogleMaps",
-			url: "https://pkgs.genexus.dev/iOS/releases/GXGoogleMaps-1.1.0.xcframework.zip",
-			checksum: "1f68dbbd1c08217a542d4d080efb8db183c39c18614ae274d8a4404ac856338b"
-		)
+					.product(name: "GXCoreUI", package: "GXCoreUI"),
+					.product(name: "GXCoreModule_Common_Maps", package: "GXCoreModule_Common_Maps"),
+					.product(name: "GXUCMaps", package: "GXUCMaps"),
+					.product(name: "GoogleMaps", package: "ios-maps-sdk"),
+					.product(name: "GoogleMapsUtils", package: "google-maps-ios-utils")
+				]),
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.9
 import PackageDescription
+import Foundation
 
 let GX_FC_LAST_VERSION = Version("3.2.0-beta")
 
@@ -10,20 +11,45 @@ let package = Package(
 		.library(name: "GXGoogleMaps", targets: ["GXGoogleMaps"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreUI.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXCoreModule_Common_Maps.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
-		.package(url: "https://github.com/GeneXus-SwiftPackages/GXUCMaps.git", .upToNextMajor(from: GX_FC_LAST_VERSION)),
 		.package(url: "https://github.com/googlemaps/ios-maps-sdk.git", .upToNextMajor(from: "9.0.0")),
 		.package(url: "https://github.com/googlemaps/google-maps-ios-utils.git", .upToNextMajor(from: "6.0.0"))
-	],
+	] + Package.Dependency.gxFrameworks(remotePackageUrls: [
+		"https://github.com/GeneXus-SwiftPackages/GXCoreUI.git",
+		"https://github.com/GeneXus-SwiftPackages/GXCoreModule_Common_Maps.git",
+		"https://github.com/GeneXus-SwiftPackages/GXUCMaps.git",
+	]),
 	targets: [
 		.target(name: "GXGoogleMaps",
 				dependencies: [
-					.product(name: "GXCoreUI", package: "GXCoreUI"),
-					.product(name: "GXCoreModule_Common_Maps", package: "GXCoreModule_Common_Maps"),
-					.product(name: "GXUCMaps", package: "GXUCMaps"),
 					.product(name: "GoogleMaps", package: "ios-maps-sdk"),
-					.product(name: "GoogleMapsUtils", package: "google-maps-ios-utils")
+					.product(name: "GoogleMapsUtils", package: "google-maps-ios-utils"),
+					.gxFrameworkProduct(name: "GXCoreUI", remotePackage: "GXCoreUI"),
+					.gxFrameworkProduct(name: "GXCoreModule_Common_Maps", remotePackage: "GXCoreModule_Common_Maps"),
+					.gxFrameworkProduct(name: "GXUCMaps", remotePackage: "GXUCMaps"),
 				]),
 	]
 )
+
+extension Package.Dependency {
+	static func gxFrameworks(remotePackageUrls: [String]) -> [Package.Dependency] {
+		if let localPath = gxFrameworksLocalPath() {
+			return [ .package(name: "GXFrameworksLocal", path: localPath) ]
+		}
+		return remotePackageUrls.map {
+			.package(url: $0, .upToNextMajor(from: GX_FC_LAST_VERSION))
+		}
+	}
+}
+
+extension Target.Dependency {
+	static func gxFrameworkProduct(name: String, remotePackage: String) -> Self {
+		.product(name: name, package: gxFrameworksLocalPath() != nil ? "GXFrameworksLocal" : remotePackage)
+	}
+}
+
+func gxFrameworksLocalPath() -> String? {
+	guard let pathCString = getenv("GX_FRAMEWORKS_LOCAL_PATH") else {
+		return nil
+	}
+	return String(cString: pathCString)
+}

--- a/Sources/Dummy.swift
+++ b/Sources/Dummy.swift
@@ -1,1 +1,0 @@
-// Swift Package Manager needs at least one source file.

--- a/Sources/GXGoogleMaps/DirectionsProvider/GMSPath+Helpers.swift
+++ b/Sources/GXGoogleMaps/DirectionsProvider/GMSPath+Helpers.swift
@@ -1,0 +1,12 @@
+//
+//  GMSPath+Helpers.swift
+//
+
+internal import GoogleMaps
+
+extension GMSPath {
+	func gxToCoordinates() -> [CLLocationCoordinate2D] {
+		let range = 0..<self.count()
+		return range.map(coordinate(at:))
+	}
+}

--- a/Sources/GXGoogleMaps/DirectionsProvider/GMSPolygon+GXPolygon.swift
+++ b/Sources/GXGoogleMaps/DirectionsProvider/GMSPolygon+GXPolygon.swift
@@ -1,0 +1,39 @@
+//
+//  GMSPolygon+GXPolygon.swift
+//
+
+import GXCoreModule_Common_Maps
+internal import GoogleMaps
+import GXObjectsModel
+
+private var GMSSDMapPolygonThemeClassKey: UInt8 = 0
+private var GMSSDMapPolygonMapAnnotationKey: UInt8 = 0
+
+internal class GXGMSPolygon: GMSPolygon, GXPolygon, GXWktRepresentable {
+	
+	var gxMapCoordinates: [CLLocationCoordinate2D] {
+		return self.path?.gxToCoordinates() ?? []
+	}
+	
+	var wktRepresentation: String {
+		return getWKTRepresentation(for: self)
+	}
+	
+	var polygonStyleClass: GXStyleClass? {
+		get {
+			return objc_getAssociatedObject(self, &GMSSDMapPolygonThemeClassKey) as? GXStyleClass
+		}
+		set {
+			objc_setAssociatedObject(self, &GMSSDMapPolygonThemeClassKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+		}
+	}
+	
+	var mapAnnotation: MKAnnotation? {
+		get {
+			objc_getAssociatedObject(self, &GMSSDMapPolygonMapAnnotationKey) as? MKAnnotation
+		}
+		set {
+			objc_setAssociatedObject(self, &GMSSDMapPolygonMapAnnotationKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+		}
+	}
+}

--- a/Sources/GXGoogleMaps/DirectionsProvider/GMSPolyline+GXPolyline.swift
+++ b/Sources/GXGoogleMaps/DirectionsProvider/GMSPolyline+GXPolyline.swift
@@ -1,0 +1,38 @@
+//
+//  GMSPolyline+GXPolyline.swift
+//
+
+import GXCoreModule_Common_Maps
+import GXObjectsModel
+internal import GoogleMaps
+
+private var GMSPolylineRouteThemeClassKey: UInt8 = 0
+private var GMSPolylineMapAnnotationKey: UInt8 = 0
+
+internal class GXGMSPolyline: GMSPolyline, GXPolyline, GXWktRepresentable {
+	var gxMapCoordinates: [CLLocationCoordinate2D] {
+		return self.path?.gxToCoordinates() ?? []
+	}
+	
+	var wktRepresentation: String {
+		return getWKTRepresentation(for: self)
+	}
+	
+	var routeStyleClass: GXStyleClass? {
+		get {
+			objc_getAssociatedObject(self, &GMSPolylineRouteThemeClassKey) as? GXStyleClass
+		}
+		set {
+			objc_setAssociatedObject(self, &GMSPolylineRouteThemeClassKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+		}
+	}
+	
+	var mapAnnotation: MKAnnotation? {
+		get {
+			objc_getAssociatedObject(self, &GMSPolylineMapAnnotationKey) as? MKAnnotation
+		}
+		set {
+			objc_setAssociatedObject(self, &GMSPolylineMapAnnotationKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+		}
+	}
+}

--- a/Sources/GXGoogleMaps/DirectionsProvider/GXGoogleMapsRoute.swift
+++ b/Sources/GXGoogleMaps/DirectionsProvider/GXGoogleMapsRoute.swift
@@ -1,0 +1,71 @@
+//
+//  GXGoogleMapsRoute.swift
+//
+
+private import GoogleMaps
+import GXCoreModule_Common_Maps
+import GXFoundation
+
+private func convertoToGMSPath(fromWKTLine line: WKTLine) -> GMSPath {
+	let path = GMSMutablePath()
+	for coordinate in line.getListPoints() as? [WKTPoint] ?? [] {
+		if let validCoordinate = coordinate.toLocation()?.coordinate, CLLocationCoordinate2DIsValid(validCoordinate) {
+			path.add(validCoordinate)
+		}
+	}
+	return path
+}
+
+private func convertoToGMSPath(fromMKCoordinates coordinates: [CLLocationCoordinate2D]) -> GMSPath {
+	let path = GMSMutablePath()
+	for coordinate in coordinates {
+		if CLLocationCoordinate2DIsValid(coordinate) {
+			path.add(coordinate)
+		}
+	}
+	return path
+}
+
+public class GXGoogleMapsRoute : NSObject, GXMapRouteWithInitialization {
+	private var path: [GMSPath] = []
+	public private(set) var name: String
+	public private(set) var advisoryNotices: [String]
+	public private(set) var distance: Double
+	public private(set) var expectedTravelTime: Double
+	public private(set) var gxTransportType: GXTransportType
+	
+	public required init?(mapRoute json: [String : Any]) {
+		if let linestringWKT = json[kRouteGeolineKey] as? String,
+			let geoline = WKTGeometry.fromWKT(linestringWKT) {
+			if let geoline = geoline as? WKTLine {
+				self.path.append(convertoToGMSPath(fromWKTLine: geoline))
+			} else if let wktLinesM = geoline as? WKTLineM, let geolines = wktLinesM.toMapMultiLine()  {
+				for geoline in geolines {
+					if let geoline = geoline as? MKPolyline {
+						self.path.append(convertoToGMSPath(fromMKCoordinates: geoline.gxMapCoordinates))
+					}
+				}
+			} else {
+				return nil
+			}
+		}
+		self.name = json[kRouteNameKey] as? String ?? ""
+		self.advisoryNotices = json[kRouteAdvisoryNoticesKey] as? [String] ?? []
+		self.distance = GXUtilities.doubleNumber(fromValue: json[kRouteDistanceKey])?.doubleValue ?? 0
+		self.expectedTravelTime = GXUtilities.doubleNumber(fromValue: json[kRouteExpectedTimeKey])?.doubleValue ?? 0
+		self.gxTransportType = GXMapUtilities.convertGXTransportType(fromRawValue: json[kRouteTransportTypeKey] as? String,
+																	 defaultValue: .any)
+	}
+	
+	public private(set) lazy var gxPolyline: [GXPolyline] = path.map(GXGMSPolyline.init(path:))
+	
+	public var dictionaryRepresentation: Dictionary<String, Any> {
+		return [ kRouteNameKey: self.name,
+	  kRouteAdvisoryNoticesKey: self.advisoryNotices,
+			 kRouteDistanceKey: self.distance,
+		 kRouteExpectedTimeKey: self.expectedTravelTime,
+		kRouteTransportTypeKey: GXMapUtilities.convertToString(from: self.gxTransportType),
+			  kRouteGeolineKey: self.gxPolyline.map(getWKTRepresentation(for:))
+		]
+	}
+}

--- a/Sources/GXGoogleMaps/DirectionsProvider/GoogleMapsDirectionsProvider.swift
+++ b/Sources/GXGoogleMaps/DirectionsProvider/GoogleMapsDirectionsProvider.swift
@@ -1,0 +1,55 @@
+//
+//  GoogleMapsDirectionsProvider.swift
+//
+
+import CoreLocation
+import GXCoreModule_Common_Maps
+import GXObjectsModel
+import MapKit
+
+@objc(GoogleMapsDirectionsProvider)
+open class GoogleMapsDirectionsProvider: NSObject, MapDirectionsHelperWithWaypoints {
+	public func calculateDirections(fromSourceLocation source: CLLocationCoordinate2D,
+									toDestinationLocation destination: CLLocationCoordinate2D,
+									withTransportType transportType: GXTransportType, requestAlternateRoutes: Bool,
+									completionHandler completionBlock: @escaping ([GXMapRoute]?, Error?) -> Void) {		
+		let requestParameters = GXDirectionServiceRequestParamters.init(sourceLocation: source,
+																		destinationLocation: destination,
+																		transportType: transportType,
+																		requestAlternateRoutes: requestAlternateRoutes,
+																		waypoints: nil,
+																		optimizeWaypoints: nil)
+		
+		GXGoogleDirectionsRequestHandlerWrapper.executeDirectionsRequest(withParameters: requestParameters,
+																		 completionBlock: completionBlock)
+	}
+
+	public func calculateDirections(withWaypoints waypoints: [CLLocationCoordinate2D],
+									withTransportType transportType: GXTransportType, requestAlternateRoutes: Bool,
+									completionHandler completionBlock: @escaping ([GXMapRoute]?, Error?) -> Void) {
+		var waypoints = waypoints
+		if waypoints.count >= 2 {
+			let source = waypoints.removeFirst()
+			let destination = waypoints.removeLast()
+			let requestParameters = GXDirectionServiceRequestParamters.init(sourceLocation: source,
+																			destinationLocation: destination,
+																			transportType: transportType,
+																			requestAlternateRoutes: requestAlternateRoutes,
+																			waypoints: waypoints,
+																			optimizeWaypoints: false)
+			
+			GXGoogleDirectionsRequestHandlerWrapper.executeDirectionsRequest(withParameters: requestParameters,
+																			 completionBlock: completionBlock)
+		}
+	}
+}
+
+private class GXGoogleDirectionsRequestHandlerWrapper: GXDirectionsServiceRequestHandlerWrapper {
+	open override class func providerName() throws -> GXDirectionServiceProvider {
+		return GXDirectionServiceProvider.Google
+	}
+	
+	open override class func providerRouteClass() throws -> GXMapRouteWithInitialization.Type {
+		return GXGoogleMapsRoute.self
+	}
+}

--- a/Sources/GXGoogleMaps/GMSMarker+MKAnnotation.swift
+++ b/Sources/GXGoogleMaps/GMSMarker+MKAnnotation.swift
@@ -1,0 +1,39 @@
+//
+//  GMSMarker+MKAnnotation.swift
+//
+
+internal import GoogleMaps
+import MapKit
+import GXCoreUI
+
+internal class GXGMSMarker: GMSMarker, GXMapAnnotationProtocol, MKAnnotation {
+	public var coordinate: CLLocationCoordinate2D {
+		get { position }
+		set { position = newValue }
+	}
+	
+	public var subtitle: String? {
+		get { snippet }
+		set { snippet = newValue }
+	}
+}
+
+internal extension GXGMSMarker {
+	/// Extract an instance of GXGoogleMapsMarker from the current marker's userData
+	/// The clustering algorithm wraps the original GMSMarker instnace inside here
+	/// - Returns: The extracted instance of ``GXGoogleMapsMarker`` (if any) or nil
+	@objc func extractCustomMarkerIfNeeded() -> GXGoogleMapsMarker? {
+		if let customMarker = self as? GXGoogleMapsMarker {
+			return customMarker
+		}
+		
+		if let userData = self.userData as? GXGoogleMapsMarker {
+			let extractedMarker = userData
+			extractedMarker.clusteringMarker = self
+			
+			return extractedMarker
+		}
+		
+		return nil
+	}
+}

--- a/Sources/GXGoogleMaps/GXControlGeoLocationGoogleMapsHelper.swift
+++ b/Sources/GXGoogleMaps/GXControlGeoLocationGoogleMapsHelper.swift
@@ -1,0 +1,174 @@
+//
+//  GXControlGeoLocationMapKitHelper.swift
+//
+
+import GXCoreUI
+internal import GoogleMaps
+
+internal class GXControlGeoLocationGoogleMapsHelper : GXControlGeoLocationHelper, GMSMapViewDelegate {
+	
+	fileprivate var loadedAnnotationGMSMarker: GXGMSMarker? {
+		guard let loadedAnnotation else {
+			return nil
+		}
+#if DEBUG
+		assert(loadedAnnotation is GXGMSMarker)
+#endif
+		return loadedAnnotation as? GXGMSMarker
+	}
+	
+	fileprivate var isDragging = false
+	
+	override func newMapView(withFrame frame: CGRect) -> (UIView & GXMapView) {
+		let mapOptions: GMSMapViewOptions = .init()
+		mapOptions.frame = frame
+		let mapView = GXControlGeoLocationGXMapView.init(options: mapOptions)
+		//mapView.animate(toZoom: 15)
+		mapView.delegate = self
+		return mapView
+	}
+	
+	deinit {
+		if let mapView = loadedMapView as? GXGoogleMapsView {
+			mapView.delegate = nil
+		}
+	}
+	
+	override func unloadMapView() {
+		if let mapView = loadedMapView as? GXGoogleMapsView {
+			mapView.delegate = nil
+		}
+		super.unloadMapView()
+	}
+}
+
+// MARK: - GMSMapViewDelegate
+
+extension GXControlGeoLocationGoogleMapsHelper {
+	func mapView(_ mapView: GMSMapView, didBeginDragging marker: GMSMarker) {
+		guard mapView == loadedMapView, marker == loadedAnnotationGMSMarker, !readOnly else { return }
+		
+		self.isDragging = true
+		
+		if self.isTrackingLocation {
+			self.stopUpdatingLocation()
+		}
+	}
+	
+	func mapView(_ mapView: GMSMapView, didEndDragging marker: GMSMarker) {
+		guard mapView == loadedMapView, let marker = marker as? GXGMSMarker, marker == loadedAnnotationGMSMarker, !readOnly else { return }
+		
+		self.isDragging = false
+		
+		self.internalUpdateAnnotationCoordinate(marker.coordinate,
+												animateChange: true,
+												animateDrop: false,
+												showAnnotationOnChange: false)
+	}
+	
+	func mapView(_ mapView: GMSMapView, didTapInfoWindowOf marker: GMSMarker) {
+		guard let gxMapView = loadedMapView,  mapView == gxMapView, let marker = marker as? GXGMSMarker, marker == loadedAnnotationGMSMarker, !readOnly else { return }
+		
+		let view = gxMapView.gxView(for: marker)
+		
+		if self.isTrackingLocation {
+			self.stopUpdatingLocation()
+		}
+		
+		if (GXUtilities.currentDeviceIPAD()) {
+			gxMapView.gxDeselect(marker, animated: false)
+		}
+		
+		let modelObject = gxMapView.gxMapViewDelegate?.mapViewModelObject(gxMapView) ?? self.delegate?.geolocationHelperModelObject(self)
+		let removePinTitle = GXResources.translation(for: kGXRemovePinString, modelObject: modelObject)
+		let cancelPinTitle = GXResources.translation(for: kGXCancelString, modelObject: modelObject)
+		let alertControler = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
+		weak var unretainedSelf = self
+		alertControler.addAction(UIAlertAction.init(title: removePinTitle,
+													style: .destructive,
+													handler: { (action) in
+														let retainedSelf = unretainedSelf
+														retainedSelf?.handleRemoveLoadedAnnotation()
+		}))
+		alertControler.addAction(UIAlertAction.init(title: cancelPinTitle,
+													style: .cancel,
+													handler: nil))
+		self.delegate?.geolocationHelper(self, present: alertControler, fromSender: view ?? gxMapView, animated: true)
+	}
+	
+	func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool {
+		if mapView == self.loadedMapView,
+		   let marker = marker as? GXGMSMarker,
+		   marker.coordinate.latitude == self.loadedAnnotationGMSMarker?.coordinate.latitude,
+		   marker.coordinate.longitude == self.loadedAnnotationGMSMarker?.coordinate.longitude {
+			self.updateReadOnly(true, updateEnabled: true, annotation: nil, mapView: nil, annotationView: nil )
+			self.reverseGeocodeLoadedAnnotation()
+		}
+		
+		return false
+	}
+	
+	func mapView(_ mapView: GMSMapView, didLongPressAt coordinate: CLLocationCoordinate2D) {
+		guard !isDragging, !readOnly else { return }
+		
+		if isTrackingLocation {
+			stopUpdatingLocation()
+		}
+		
+		mapView.clear()
+		internalUpdateAnnotationCoordinate(coordinate,
+										   animateChange: true,
+										   animateDrop: true,
+										   showAnnotationOnChange: loadedAnnotation != nil)
+		if let annotation = loadedAnnotation {
+			(mapView as? GXMapView)?.gxSelect(annotation, animated: true)
+		}
+	}
+	
+	override static func createEmptyAnnotation() -> any GXMapAnnotationProtocol {
+		let marker = GXGMSMarker.init()
+		marker.isDraggable = true
+		return marker
+	}
+}
+
+internal class GXControlGeoLocationGXMapView : GXGoogleMapsView {
+	private var tintColorIsCustom: Bool = false
+	
+	override func didMoveToSuperview() {
+		super.didMoveToSuperview()
+		self.adjustTintColorIfNeeded()
+	}
+	
+	override func didMoveToWindow() {
+		super.didMoveToWindow()
+		self.adjustTintColorIfNeeded()
+	}
+	
+	private func adjustTintColorIfNeeded() {
+		if let superview = self.superview, let _ = self.window {
+			let keyColor: UIColor = superview.tintColor
+			if keyColor.gxHasLowContrastAgainstUserInterfaceStyle(from: self.traitCollection) {
+				if (!self.tintColorIsCustom) {
+					super.tintColor = GXUIKitConstants.UIColorDefaultKeyColor
+				}
+			} else if (!keyColor.isEqual(self.tintColor)) {
+				tintColorIsCustom = false
+				super.tintColor = nil
+			}
+		}
+	}
+	
+	override var tintColor: UIColor! {
+		get {
+			return super.tintColor
+		}
+		set {
+			if (newValue != nil) {
+				tintColorIsCustom = true
+				super.tintColor = nil
+				self.adjustTintColorIfNeeded()
+			}
+		}
+	}
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsExtensionLibrary.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsExtensionLibrary.swift
@@ -8,8 +8,12 @@ import GXCoreBL
 open class GXGoogleMapsExtensionLibrary: NSObject, GXExtensionLibraryProtocol {
     
     open func initializeExtensionLibrary(withContext context: GXExtensionLibraryContext) {
-        let googleMapsProvider = GXGoogleMapsMapsProvider()
+		let googleMapsProvider = newMapProvider()
         GXMapsProvidersManager.register(googleMapsProvider, forIdentifier: googleMapsProvider.mapsApiIdentifier)
     }
+	
+	open func newMapProvider() -> GXGoogleMapsMapsProvider {
+		GXGoogleMapsMapsProvider()
+	}
 }
 

--- a/Sources/GXGoogleMaps/GXGoogleMapsExtensionLibrary.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsExtensionLibrary.swift
@@ -1,0 +1,15 @@
+//
+//  GXMapsProvider_GoogleMapsExtensionLibrary.swift
+//
+
+import GXCoreBL
+
+@objc(GXGoogleMapsExtensionLibrary)
+open class GXGoogleMapsExtensionLibrary: NSObject, GXExtensionLibraryProtocol {
+    
+    open func initializeExtensionLibrary(withContext context: GXExtensionLibraryContext) {
+        let googleMapsProvider = GXGoogleMapsMapsProvider()
+        GXMapsProvidersManager.register(googleMapsProvider, forIdentifier: googleMapsProvider.mapsApiIdentifier)
+    }
+}
+

--- a/Sources/GXGoogleMaps/GXGoogleMapsList+GeoLayers.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsList+GeoLayers.swift
@@ -1,0 +1,34 @@
+//
+//  GXGoogleMapsList+GeoLayers.swift
+//
+
+internal import GoogleMaps
+internal import GoogleMapsUtils
+import GXUCMaps
+
+extension GXGoogleMapsList {
+	
+	open override func executeMethod_LoadKMLLayer(_ layerId: String, layerData: String, allowSelection: Bool) -> Int {
+		let layerData = Self.unescapeKMLString(layerData)
+		guard let data = layerData.data(using: .utf8) else {
+			return Int(GXMapsLoadLayerErrorCode.invalidKML.rawValue)
+		}
+		
+		let kmlParser = GMUKMLParser(data: data)
+		kmlParser.parse()
+		
+		guard let gmsMapView = self.googleMapView else {
+			return -1 // TODO Geolayers
+		}
+		let renderer = GMUGeometryRenderer(map: gmsMapView, geometries: kmlParser.placemarks, styles: kmlParser.styles)
+		
+		renderer.render()
+		for overlay in renderer.mapOverlays() {
+			(overlay as? GXGoogleMapsMarker)?.isPersistent = true
+			gmsMapView.overlays.insert(overlay)
+		}
+		
+		return Int(GXMapsLoadLayerErrorCode.ok.rawValue)
+	}
+	
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsList+Routing.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsList+Routing.swift
@@ -1,0 +1,114 @@
+//
+//  GXGoogleMapsList+Routing.swift
+//
+
+import GXCoreModule_Common_Maps
+internal import GoogleMaps
+import GXObjectsModel
+
+internal extension GXGoogleMapsList {
+
+	override func drawPolyline(polylines: [GXPolyline], isRefreshable: Bool) {
+		guard let mapView = self.googleMapView else { return }
+		
+		for polyline in polylines {
+			var shouldApplyStyle = false
+			let gmsPolyline: GMSPolyline
+			if let gmsPolyline_ = polyline as? GMSPolyline {
+				gmsPolyline = gmsPolyline_
+				// heuritic: if the width and color are the defaults, apply the class. If they have other info, then don't
+				shouldApplyStyle = gmsPolyline.strokeWidth == 1.0 && gmsPolyline.strokeColor == UIColor.blue
+			}
+			else {
+				let path = polyline.gxMapCoordinates
+					.reduce(GMSMutablePath()) { path, coordinate in
+						path.add(coordinate)
+						return path
+					}
+				
+				gmsPolyline = GMSPolyline(path: path)
+				shouldApplyStyle = true
+			}
+			
+			if shouldApplyStyle {
+				let styleClass = polyline.routeStyleClass ?? self.routeStyleClass
+				let resolver = GXStyleClassHelper.propertyDefaultResolver(for: styleClass, fallback: nil)
+				DispatchQueue.gxSyncOnMain {
+					if let styleClass = styleClass {
+						gmsPolyline.strokeWidth = SDMapRouteThemeClass.lineWidth(from: styleClass, resolvingToDefaultWith: resolver)
+						let strokeColor: UIColor = SDMapRouteThemeClass.strokeColor(from: styleClass, resolvingToDefaultWith: resolver) ?? mapView.tintColor
+						if let dashPattern = SDMapRouteThemeClass.lineDashPattern(from: styleClass, resolvingToDefaultWith: resolver) {
+							var colors = [GMSStrokeStyle]()
+							var lenghts = [NSNumber]()
+							let strokeStyle = GMSStrokeStyle.solidColor(strokeColor)
+							let clearStrokeStyle = GMSStrokeStyle.solidColor(UIColor.clear)
+							
+							for (index, patternLength) in dashPattern.enumerated() {
+								lenghts.append(patternLength)
+								colors.append((index % 2 == 0) ? clearStrokeStyle : strokeStyle)
+							}
+							if let path = gmsPolyline.path {
+								gmsPolyline.spans = GMSStyleSpans(path, colors, lenghts, .rhumb)
+							}
+						} else {
+							gmsPolyline.strokeColor = strokeColor
+						}
+					}
+				}
+			}
+			mapView.gxAdd(gmsPolyline, isRefreshable: isRefreshable)
+		}
+	}
+	
+	override func drawPolygon(_ polygon: GXPolygon, isRefreshable: Bool) {
+		guard let mapView = self.googleMapView else { return }
+		
+		var gmsPolygon: GMSPolygon!
+		if let polygon = polygon as? GMSPolygon {
+			gmsPolygon = polygon
+		}
+		else {
+			let path = GMSPath.path(from: polygon.gxMapCoordinates)
+			let styleClass = polygon.polygonStyleClass ?? self.polygonStyleClass
+			let resolver = GXStyleClassHelper.propertyDefaultResolver(for: styleClass, fallback: nil)
+			DispatchQueue.gxSyncOnMain {
+				gmsPolygon = GXGMSPolygon.init(path: path)
+				if let styleClass = styleClass {
+					gmsPolygon.fillColor = SDMapPolygonThemeClass.fillColor(from: styleClass, resolvingToDefaultWith: resolver)
+					gmsPolygon.strokeWidth = SDMapPolygonThemeClass.lineWidth(from: styleClass, resolvingToDefaultWith: resolver)
+					let strokeColor: UIColor = SDMapPolygonThemeClass.strokeColor(from: styleClass, resolvingToDefaultWith: resolver) ?? mapView.tintColor
+// MARK: TODO: GMSPolygon does not have the .spans property
+//					if let dashPattern = themeClass.lineDashPattern {
+//						var colors = [GMSStrokeStyle]()
+//						var lenghts = [NSNumber]()
+//						let strokeStyle = GMSStrokeStyle.solidColor(strokeColor)
+//						let clearStrokeStyle = GMSStrokeStyle.solidColor(UIColor.clear)
+//
+//						for (index, patternLength) in dashPattern.enumerated() {
+//							lenghts.append(patternLength)
+//							colors.append((index % 2 == 0) ? clearStrokeStyle : strokeStyle)
+//						}
+//						if let path = gmsPolygon.path {
+//							gmsPolygon.spans = GMSStyleSpans(path, colors, lenghts, .rhumb)
+//						}
+//					} else {
+						gmsPolygon.strokeColor = strokeColor
+//					}
+				}
+			}
+		}
+		
+		mapView.gxAdd(gmsPolygon, isRefreshable: isRefreshable)
+	}
+}
+
+internal extension GMSPath {
+	
+	static func path(from coordinates: [CLLocationCoordinate2D]) -> GMSPath {
+		let path = GMSMutablePath.init()
+		for coordinate in coordinates {
+			path.add(coordinate)
+		}
+		return path
+	}
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsList.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsList.swift
@@ -1,0 +1,530 @@
+import UIKit
+import CoreLocation
+internal import GoogleMaps
+import GXUCMaps
+
+@objc(GXGoogleMapsList)
+internal class GXGoogleMapsList: GXUC_MapList {
+	
+	// MARK: - Properties
+	private var regionChangedSinceLastZoomToFitMapAnnotations = false
+	private var openedInfoWindow: GXUC_MapListCalloutAnnotationView?
+	private var mapViewEdgePadding = UIEdgeInsets.zero
+	private var infoWindowAnimationTimer: Timer?
+	//private var isCalloutVisible = false
+	private var isHandlingCalloutTap = false
+	private var cancelNextCameraMovement = false
+	private var ignoreNextCameraMovement = false
+	
+	
+	internal var googleMapView: GXGoogleMapsView? {
+		gridView as? GXGoogleMapsView
+	}
+	
+	// MARK: - Lifecycle
+	
+	/// Creates a new grid view with the specified frame.
+	///
+	/// - Parameter frame: The frame rectangle for the view, measured in points.
+	/// - Returns: A new `UIView` instance configured as a Google Maps view.
+	override func newGridView(withFrame frame: CGRect) -> UIView {
+		regionChangedSinceLastZoomToFitMapAnnotations = false
+		
+		let mapOptions = GMSMapViewOptions()
+		mapOptions.frame = frame
+		
+		let mapView = GXGoogleMapsView(options: mapOptions)
+		configureMapView(mapView)
+		
+		return mapView
+	}
+	
+	/// Configures the provided Google Maps view with the necessary settings.
+	///
+	/// - Parameter mapView: The `GXGoogleMapsView` instance to configure.
+	private func configureMapView(_ mapView: GXGoogleMapsView) {
+		mapView.insetsLayoutMarginsFromSafeArea = false
+		mapView.layoutMargins = .zero
+		mapViewEdgePadding = .zero
+		mapView.preservesSuperviewLayoutMargins = false
+		mapView.delegate = self
+		mapView.gxGMSMapViewDelegate = self
+		mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+		mapView.gxSetGXMapType(mapType)
+		mapView.isTrafficEnabled = showTraffic
+		mapView.clusterMarkers = isClusteringEnabled
+		
+		if showMyLocation && requestLocationAuthorizationIfNeeded() {
+			mapView.gxSetShowsUserLocation(true)
+		}
+	}
+	
+	/// Updates the theme class for the grid view entity data cells grid item.
+	///
+	/// This method overrides the superclass implementation to specifically handle the theme class for the Google Maps view.
+	/// It ensures that the `openedInfoWindow`'s style class is updated based on the list item style configuration.
+	///
+	/// - Parameter gridView: The `UIView` instance representing the grid view.
+	override func updateGridViewEntityDataCellsGridItemThemeClass(_ gridView: UIView) {
+		super.updateGridViewEntityDataCellsGridItemThemeClass(gridView)
+		
+		guard mapView == gridView, let openedInfoWindow else { return }
+		
+		if sameOddAndEvenListItemStyleClass {
+			openedInfoWindow.gridItemStyleClass = listItemEvenItemClass
+		} else if let pinMarker = self.openedInfoWindow?.annotation as? GXGoogleMapsPinMarker, let indexPath = pinMarker.indexPath {
+			let evenCell = indexPath.gxEntityDataIndex % 2 != 0
+			openedInfoWindow.gridItemStyleClass = evenCell ? listItemEvenItemClass : listItemOddItemClass
+		}
+	}
+	
+	/// Deinitializes the instance and performs necessary cleanup.
+	///
+	/// This method ensures that the Google Maps view is properly cleaned up by calling `cleanupMapView` before the instance is deallocated.
+	deinit {
+		cleanupMapView()
+	}
+	
+	// MARK: - View Management
+	
+	/// Unloads the view and performs necessary cleanup.
+	///
+	/// This method overrides the superclass implementation to include additional cleanup specific to the Google Maps view.
+	override func unloadView() {
+		cleanupMapView()
+		super.unloadView()
+	}
+	
+	/// Cleans up the Google Maps view by removing its delegates.
+	private func cleanupMapView() {
+		googleMapView?.delegate = nil
+		googleMapView?.gxGMSMapViewDelegate = nil
+	}
+	
+	/// The frame rectangle for the view, measured in points.
+	///
+	/// This property overrides the superclass implementation to handle specific behavior when the frame size changes.
+	/// If the frame is empty or its size changes, it cancels the next camera movement.
+	override var frame: CGRect {
+		get {
+			super.frame
+		}
+		set {
+			if self.frame.isEmpty || self.frame.size != newValue.size {
+				cancelNextCameraMovement = true
+			}
+			super.frame = newValue
+		}
+	}
+	
+	/// Zooms the map to fit all annotations.
+	///
+	/// This method overrides the superclass implementation to ensure that the map view properly adjusts before zooming.
+	/// It prepares the map view for the zoom operation.
+	///
+	/// - Parameter animated: A Boolean value indicating whether the zoom should be animated.
+	override func zoom(toFitMapAnnotations animated: Bool) {
+		cancelNextCameraMovement = false
+		super.zoom(toFitMapAnnotations: animated)
+	}
+	
+	// MARK: - Info Window Management
+	
+	/// Disables the refresh of the pin info window.
+	///
+	/// This method stops the info window from updating its content while an animation is in progress.
+	/// It also invalidates and clears the info window animation timer.
+	@objc private func disablePinInfoWindowRefresh() {
+		guard ((openedInfoWindow?.layer.animationKeys()?.isEmpty) != nil) else { return }
+		
+		self.googleMapView?.selectedMarker?.tracksInfoWindowChanges = false
+		infoWindowAnimationTimer?.invalidate()
+		infoWindowAnimationTimer = nil
+	}
+	
+	// MARK: - Annotation Management
+	
+	/// Adds an annotation to the map at the specified location.
+	///
+	/// This method creates a new pin annotation with the provided location, entity data, and other parameters.
+	/// The annotation is then added to the map view.
+	///
+	/// - Parameters:
+	///   - location: The coordinate where the annotation should be placed.
+	///   - entityData: The data associated with the annotation.
+	///   - indexPath: The index path of the annotation in the data source.
+	///   - animationKey: An optional key for identifying the animation.
+	///   - pinImageFieldValue: An optional value for the pin image.
+	///   - pinImageStyleClass: An optional style class for the pin image.
+	///   - geometryLayerId: An optional identifier for the geometry layer.
+	/// - Returns: The created pin annotation.
+	override func addAnnotation(
+		withLocation location: CLLocationCoordinate2D,
+		entitiyData entityData: GXEntityData,
+		indexPath: IndexPath?,
+		animationKey: String?,
+		pinImageFieldValue: Any?,
+		pinImageStyleClass: GXStyleClass?,
+		geometryLayerId: String?
+	) -> GXUC_MapPinAnnotation {
+		let pin = GXGoogleMapsPinMarker(
+			location: location,
+			entityData: entityData,
+			indexPath: indexPath,
+			animationKey: animationKey,
+			geometryLayerId: geometryLayerId
+		)
+		
+		pin.pinImageFieldValue = pinImageFieldValue
+		pin.pinImageStyleClass = pinImageStyleClass
+		
+		mapView?.gxAdd(pin, isPersistent: false)
+		
+		return pin
+	}
+	
+	/// Updates the position of an existing annotation with an animation.
+	///
+	/// This method moves the specified annotation to a new position over a given duration.
+	/// The animation can be repeated or the annotation can be removed based on the repeat behavior.
+	///
+	/// - Parameters:
+	///   - annotation: The annotation to be moved.
+	///   - position: The new coordinate for the annotation.
+	///   - duration: The duration of the animation.
+	///   - repeatBehavior: The behavior to apply when the animation completes.
+	func update(
+		annotation: GXUC_MapPinAnnotation,
+		toPosition position: CLLocationCoordinate2D,
+		withDuration duration: TimeInterval,
+		repeatBehavior: GXUCMapListAnimationEndBehavior
+	) {
+		let initialPosition = annotation.coordinate
+		
+		guard initialPosition.latitude != position.latitude ||
+				initialPosition.longitude != position.longitude else { return }
+		
+		guard let marker = annotation as? GXGoogleMapsPinMarker else { return }
+		
+		let animationIndex = marker.animationIndex + 1
+		marker.animationIndex = animationIndex
+		
+		animate(
+			marker: marker,
+			toPosition: position,
+			duration: duration,
+			repeatBehavior: repeatBehavior,
+			animationIndex: animationIndex
+		)
+	}
+	
+	/// Animates the movement of a marker to a new position.
+	///
+	/// This private method handles the core animation logic for moving a specified marker to a new position over a given duration.
+	/// It supports different behaviors upon animation completion, such as repeating the animation, removing the marker, or simply stopping.
+	///
+	/// - Parameters:
+	///   - marker: The marker to be animated.
+	///   - position: The new coordinate for the marker.
+	///   - duration: The duration of the animation.
+	///   - repeatBehavior: The behavior to apply when the animation completes.
+	///     - `.repeat`: The animation will repeat, moving the marker back to its initial position.
+	///     - `.disappear`: The marker will be removed from the map upon animation completion.
+	///     - `.stop`: The animation will stop, leaving the marker at the new position.
+	///   - animationIndex: The index of the current animation, used to ensure the correct animation is being processed.
+	private func animate(
+		marker: GXGoogleMapsPinMarker,
+		toPosition position: CLLocationCoordinate2D,
+		duration: TimeInterval,
+		repeatBehavior: GXUCMapListAnimationEndBehavior,
+		animationIndex: UInt
+	) {
+		let initialPosition = marker.position
+		
+		CATransaction.begin()
+		CATransaction.setAnimationDuration(duration)
+		
+		CATransaction.setCompletionBlock { [weak self] in
+			guard let self = self,
+				  animationIndex == marker.animationIndex else { return }
+			
+			switch repeatBehavior {
+			case .repeat:
+				self.animate(
+					marker: marker,
+					toPosition: initialPosition,
+					duration: duration,
+					repeatBehavior: repeatBehavior,
+					animationIndex: animationIndex
+				)
+			case .disappear:
+				self.mapView?.gxRemove(marker)
+				if let animationKey = marker.animationKey {
+					self.removeAnimatedAnnotation(withKey: animationKey)
+				} else {
+#if DEBUG
+					assertionFailure("Tried to remove market without an animationKey")
+#endif
+				}
+			default:
+				break
+			}
+		}
+		
+		marker.position = position
+		CATransaction.commit()
+	}
+}
+
+extension GXGoogleMapsList : GXGMSMapViewDelegate {
+	/// Returns a custom or default annotation view for the specified marker.
+	/// - Parameters:
+	///   - mapView: The GMSMapView that requested the annotation view.
+	///   - marker: A custom GXGoogleMapsPinMarker associated with the requested view.
+	/// - Returns: A UIView (MKAnnotationView subclass) representing the marker, or nil to use a default view.
+	func mapView(_ mapView: GMSMapView, iconViewFor marker: GMSMarker) -> UIView? {
+		guard let marker = marker as? GXGoogleMapsPinMarker else {
+#if DEBUG
+			preconditionFailure("Unexpected marker type")
+#else
+			return nil
+#endif
+		}
+		
+		/// Check if there's a valid pin image; if not, use the default pin view.
+		let useDefaultPinView = GXUtilities.nonEmptyString(from: marker.pinImageFieldValue) == nil
+		var markerIconView: MKAnnotationView?
+		
+		if useDefaultPinView {
+			// No custom icon needed
+			markerIconView = nil
+		} else {
+			// Try casting our current view; if nil, create a new custom view
+			let customView = GXUC_MapCustomAnnotationView(annotation: marker, reuseIdentifier: nil)
+			
+			// Apply the pin image from entity data
+			customView.gxSetImage(fromEntityDataFieldValue: marker.pinImageFieldValue, modelObject: self.layoutElement)
+			
+			// Adjust marker offset so the pin tip aligns with its coordinate
+			let height = markerIconView?.bounds.size.height ?? 0
+			markerIconView?.centerOffset = CGPoint(x: 0, y: -height / 2)
+			
+			// Disable default callout and set callout offset
+			markerIconView?.canShowCallout = false
+			markerIconView?.calloutOffset = CGPoint(x: -5, y: 5) // Match MapKit's offset
+			
+			markerIconView = customView
+		}
+		
+		return markerIconView
+	}
+	
+	/// Returns a custom callout view for the specified marker.
+	/// - Parameters:
+	///   - mapView: The GMSMapView that requested the callout view.
+	///   - marker: A custom GXGoogleMapsPinMarker for which the callout view is provided.
+	/// - Returns: A UIView representing the custom callout, or nil for no custom callout.
+	func mapView(_ mapView: GMSMapView, calloutViewFor marker: GMSMarker) -> UIView? {
+		guard let marker = marker as? GXGoogleMapsPinMarker else {
+#if DEBUG
+			preconditionFailure("Unexpected marker type")
+#else
+			return nil
+#endif
+		}
+		
+		guard let indexPath = marker.indexPath else { return nil }
+		let pIndexPathRow = indexPath.gxEntityDataIndex
+		let pIndexPathSection = indexPath.gxEntityDataSection
+		
+		/// This is zero-based, but in GX it is one-based; hence, we check for != 0 to determine evenness (what would be odd in GX is even here).
+		let evenCell = pIndexPathRow % 2 != 0
+		
+		// Select the appropriate style class based on row parity
+		let listItemStyleClass = evenCell ? self.listItemEvenItemClass : self.listItemOddItemClass
+		
+		// Inner table that represents the content displayed in the callout
+		let innerTable = self.gxControlTableForEntity(at: UInt(pIndexPathRow), section: UInt(pIndexPathSection))
+		let calloutMapAnnotationView = GXUC_MapListCalloutAnnotationView(
+			innerTable: innerTable,
+			annotation: marker.clusteringMarkerOrSelf,
+			reuseIdentifier: nil
+		)
+		
+		calloutMapAnnotationView.gridItemDelegate = self
+		calloutMapAnnotationView.gridItemHighlightStyleModifiers = .highlightAllowed
+		calloutMapAnnotationView.gridItemStyleClass = listItemStyleClass
+		
+		self.openedInfoWindow = calloutMapAnnotationView
+		
+		return calloutMapAnnotationView
+	}
+	
+	/// Called when a marker is selected on the map.
+	/// - Parameters:
+	///   - mapView: The GMSMapView reporting the event.
+	///   - marker: The selected GMSMarker.
+	func mapView(_ mapView: GMSMapView, didSelect marker: GMSMarker) {
+		fireSelectionChangedEvent()
+	}
+	
+	/// Called when a marker is deselected on the map.
+	/// - Parameters:
+	///   - mapView: The GMSMapView reporting the event.
+	///   - didDeselectMarker: The GMSMarker that was deselected.
+	func mapView(_ mapView: GMSMapView, didDeselectMarker: GMSMarker) {
+		fireSelectionChangedEvent()
+	}
+}
+
+// MARK: - GMSMapViewDelegate
+
+extension GXGoogleMapsList: GMSMapViewDelegate {
+	
+	/// Called when the map view is about to move.
+	///
+	/// This delegate method handles the behavior when the map view is about to move, either due to a gesture or programmatically.
+	/// If a camera movement cancellation is flagged, it prevents the camera from moving and resets it to the current position.
+	/// Otherwise, it marks that the region has changed since the last zoom to fit map annotations.
+	///
+	/// - Parameter mapView: The `GMSMapView` instance that is about to move.
+	/// - Parameter gesture: A Boolean value indicating whether the movement is caused by a user gesture.
+	func mapView(_ mapView: GMSMapView, willMove gesture: Bool) {
+		if cancelNextCameraMovement {
+			cancelNextCameraMovement = false
+			ignoreNextCameraMovement = true
+			mapView.camera = mapView.camera // Reset the camera to the current position
+		} else {
+			regionChangedSinceLastZoomToFitMapAnnotations = true
+		}
+	}
+	
+	/// Called when the map view's camera position changes.
+	///
+	/// This delegate method handles the behavior when the map view's camera position changes.
+	/// If the selection layer is enabled and the camera movement is not being ignored, it fires a `GXControlEventNameControlValueChanging` event.
+	/// This indicates that the control value is in the process of changing due to the camera movement.
+	///
+	/// - Parameter mapView: The `GMSMapView` instance whose camera position changed.
+	/// - Parameter position: The new camera position.
+	func mapView(_ mapView: GMSMapView, didChange position: GMSCameraPosition) {
+		if !ignoreNextCameraMovement, isSelectionLayerEnabled {
+			fireLocationSelectionEventIfNeeded(withName: GXControlEventNameControlValueChanging)
+		}
+	}
+	
+	/// Called when the map view becomes idle after a camera movement.
+	///
+	/// This delegate method handles the behavior when the map view becomes idle after a camera movement.
+	/// If the selection layer is enabled and the camera movement is not being ignored, it fires a `GXControlEventNameControlValueChanged` event.
+	/// This indicates that the control value has finished changing as the camera movement has come to a stop.
+	///
+	/// - Parameter mapView: The `GMSMapView` instance that became idle.
+	/// - Parameter position: The camera position at the time the map view became idle.
+	func mapView(_ mapView: GMSMapView, idleAt position: GMSCameraPosition) {
+		if !ignoreNextCameraMovement, isSelectionLayerEnabled {
+			fireLocationSelectionEventIfNeeded(withName: GXControlEventNameControlValueChanged)
+		}
+		ignoreNextCameraMovement = false
+	}
+	
+	/// Provides a custom info window for the specified marker.
+	///
+	/// This delegate method returns a custom view to be used as the info window for the specified marker.
+	/// If the marker is of the correct type and has a non-empty callout layout, it makes the callout visible and prepares the info window for display.
+	///
+	/// - Parameter mapView: The `GMSMapView` instance requesting the info window.
+	/// - Parameter marker: The `GMSMarker` instance for which the info window is requested.
+	/// - Returns: A `UIView` instance to be used as the info window, or `nil` if no custom info window is provided.
+	func mapView(_ mapView: GMSMapView, markerInfoWindow marker: GMSMarker) -> UIView? {
+		guard let marker = marker as? GXGMSMarker else {
+#if DEBUG
+			assertionFailure("Invalid marker type")
+#endif
+			return nil
+		}
+		
+		let actualMarker = marker.extractCustomMarkerIfNeeded()
+		
+		guard let pinMarker = actualMarker as? GXGoogleMapsPinMarker, !isCalloutLayoutEmpty(for: pinMarker) else { return nil }
+		
+		//isCalloutVisible = true
+		pinMarker.clusteringMarkerOrSelf.tracksInfoWindowChanges = true
+		
+		let view = self.mapView(mapView, calloutViewFor: pinMarker)
+		
+		infoWindowAnimationTimer = Timer.scheduledTimer(
+			timeInterval: 1,
+			target: self,
+			selector: #selector(disablePinInfoWindowRefresh),
+			userInfo: nil,
+			repeats: false)
+		
+		return view
+	}
+	
+	/// Handles the event when the info window of a marker on the map is closed.
+	///
+	/// - Parameters:
+	/// - mapView: The GMSMapView instance that triggered the event.
+	/// - marker: The marker whose info window was closed.
+	func mapView(_ mapView: GMSMapView, didCloseInfoWindowOf marker: GMSMarker) {
+		// Check if the marker is of a custom type to update callout visibility
+		if marker is GXGoogleMapsPinMarker {
+			//_isCalloutVisible = false
+		}
+		
+		// Invalidate and clear the info window animation timer
+		infoWindowAnimationTimer?.invalidate()
+		infoWindowAnimationTimer = nil
+		
+		// Clear the opened info window reference
+		self.openedInfoWindow = nil
+	}
+	
+	/// Handles the event when the info window of a marker on the map is tapped.
+	///
+	/// - Parameters:
+	/// - mapView: The GMSMapView instance that triggered the event.
+	/// - marker: The marker whose info window was tapped.
+	func mapView(_ mapView: GMSMapView, didTapInfoWindowOf marker: GMSMarker) {
+		guard let marker = marker as? GXGoogleMapsPinMarker else {
+			return
+		}
+		
+		self.isHandlingCalloutTap = true
+		
+		guard let indexPath = marker.indexPath else {
+			return
+		}
+		
+		// Extract entity data indices from the marker
+		let pIndexPathRow = UInt(indexPath.gxEntityDataIndex)
+		let pIndexPathSection = UInt(indexPath.gxEntityDataSection)
+		
+		let infoWindow = self.openedInfoWindow
+		
+		// Delay the default action so the selection event fires first
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+			guard let self else { return }
+			
+			if self.canExecuteDefaultActionForEntity(at: pIndexPathRow, section: pIndexPathSection) {
+				self.executeDefaultActionForEntity(
+					at: pIndexPathRow,
+					section: pIndexPathSection,
+					from: infoWindow?.gridItemTable
+				)
+			}
+		}
+		
+		// Deselect the marker to visually dismiss it
+		googleMapView?.gxDeselect(marker, animated: true)
+		
+		// After a delay, reset the handling state so it doesn't affect other markers
+		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+			guard let self else { return }
+			
+			self.isHandlingCalloutTap = false
+		}
+	}
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsMapsProvider.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsMapsProvider.swift
@@ -6,7 +6,7 @@ import GXCoreBL
 internal import GoogleMaps
 
 @objc(GXGoogleMapsMapsProvider)
-class GXGoogleMapsMapsProvider : NSObject, GXMapsProviderProtocol {
+open class GXGoogleMapsMapsProvider : NSObject, GXMapsProviderProtocol {
 	
 	private let GoogleMapsApiIdentifier = "MAPS_GOOGLE"
 	private let controlClasses: [GXMapsProvidersManager.MapControlType: AnyClass] = [
@@ -17,22 +17,22 @@ class GXGoogleMapsMapsProvider : NSObject, GXMapsProviderProtocol {
 	
 	private var isInitialized: Bool = false
     
-    @objc var mapsApiIdentifier: String {
+    @objc public var mapsApiIdentifier: String {
         GoogleMapsApiIdentifier
     }
     
-    @objc var initializationIsRequiered: Bool {
+    @objc open var initializationIsRequiered: Bool {
 		return !isInitialized && !GXMiniProgramsHelper.isSuperAppNonGXApp
     }
     
-    @objc func getClass(forControlType controlType: String) -> AnyClass? {
+    @objc open func getClass(forControlType controlType: String) -> AnyClass? {
 		guard let knownControlType = GXMapsProvidersManager.MapControlType(rawValue: controlType) else {
 			return nil
 		}
         return controlClasses[knownControlType]
     }
     
-    @objc func initializeProvider() {
+    @objc open func initializeProvider() {
 		guard initializationIsRequiered else {
 			return
 		}
@@ -44,12 +44,15 @@ class GXGoogleMapsMapsProvider : NSObject, GXMapsProviderProtocol {
         isInitialized = true
         GMSServices.provideAPIKey(apiKey)
     }
-    
-    // MARK: - Private Helpers
 	
-	private func getApiKey() -> String? {
-		GXModelManager.shared.activeModels.compactMapFirst { gxModel in
-			guard gxModel.appModel.isEmbeddedApplication else {	return nil }
+	/// Initialization API key is extracted from the returned models
+	open var modelsForAPIKey: [GXModel] {
+		GXModelManager.shared.activeModels.filter(\.appModel.isEmbeddedApplication)
+	}
+	
+	/// Extracts initialization API key from `modelsForAPIKey`
+	public func getApiKey() -> String? {
+		modelsForAPIKey.compactMapFirst { gxModel in
 			let appEntryPoint = gxModel.appModel.mainEntryPoint
 			guard let apiKey = appEntryPoint.value(forAppEntryPointProperty: kAppEntryPointPropertyAppleMapsApiKey) as? String,
 				  let mapsProviderId = appEntryPoint.value(forAppEntryPointProperty: kAppEntryPointPropertyAppleMapsApi) as? String,

--- a/Sources/GXGoogleMaps/GXGoogleMapsMapsProvider.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsMapsProvider.swift
@@ -1,0 +1,62 @@
+//
+//  GXGoogleMapsMapsProvider.swift
+//
+
+import GXCoreBL
+internal import GoogleMaps
+
+@objc(GXGoogleMapsMapsProvider)
+class GXGoogleMapsMapsProvider : NSObject, GXMapsProviderProtocol {
+	
+	private let GoogleMapsApiIdentifier = "MAPS_GOOGLE"
+	private let controlClasses: [GXMapsProvidersManager.MapControlType: AnyClass] = [
+		.sdMaps: GXGoogleMapsList.self,
+		.geoLocationHelper: GXControlGeoLocationGoogleMapsHelper.self,
+		.directionsProvider: GoogleMapsDirectionsProvider.self
+	]
+	
+	private var isInitialized: Bool = false
+    
+    @objc var mapsApiIdentifier: String {
+        GoogleMapsApiIdentifier
+    }
+    
+    @objc var initializationIsRequiered: Bool {
+		return !isInitialized && !GXMiniProgramsHelper.isSuperAppNonGXApp
+    }
+    
+    @objc func getClass(forControlType controlType: String) -> AnyClass? {
+		guard let knownControlType = GXMapsProvidersManager.MapControlType(rawValue: controlType) else {
+			return nil
+		}
+        return controlClasses[knownControlType]
+    }
+    
+    @objc func initializeProvider() {
+		guard initializationIsRequiered else {
+			return
+		}
+		guard let apiKey = getApiKey() else {
+			let log = GXFoundationServices.loggerService()
+			log?.logMessage("Google Maps API key was not found", for: .general, with: .warning, logToConsole: true)
+            return
+        }
+        isInitialized = true
+        GMSServices.provideAPIKey(apiKey)
+    }
+    
+    // MARK: - Private Helpers
+	
+	private func getApiKey() -> String? {
+		GXModelManager.shared.activeModels.compactMapFirst { gxModel in
+			guard gxModel.appModel.isEmbeddedApplication else {	return nil }
+			let appEntryPoint = gxModel.appModel.mainEntryPoint
+			guard let apiKey = appEntryPoint.value(forAppEntryPointProperty: kAppEntryPointPropertyAppleMapsApiKey) as? String,
+				  let mapsProviderId = appEntryPoint.value(forAppEntryPointProperty: kAppEntryPointPropertyAppleMapsApi) as? String,
+				  mapsProviderId == GoogleMapsApiIdentifier else {
+				return nil
+			}
+			return apiKey
+		}
+    }
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsPinMarker.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsPinMarker.swift
@@ -1,0 +1,64 @@
+//
+//  GXUC_MapsPinMarker.swift
+//
+
+import GXCoreUI
+internal import GoogleMaps
+
+internal class GXGoogleMapsPinMarker : GXGoogleMapsMarker, GXUC_MapPinAnnotation {
+	
+	public var entityData: GXEntityData
+    
+    public var indexPath: IndexPath?
+	
+	public var animationKey: String?
+	
+	public var geometryLayerId: String?
+	
+	public var geometryId: String
+    
+    public var pinImageFieldValue: Any?
+    
+    public var pinImageStyleClass: GXStyleClass?
+	
+	public var annotationView: UIView?
+	
+	public var animationIndex: UInt;
+    
+	public required init(location: CLLocationCoordinate2D, entityData: GXEntityData, indexPath: IndexPath?, animationKey: String?, geometryLayerId: String?) {
+        self.entityData = entityData
+        self.indexPath  = indexPath
+		self.animationKey = animationKey
+		self.animationIndex = UInt.min
+		self.geometryLayerId = geometryLayerId
+		self.geometryId = GXUUID.create().uuidString
+		
+        super.init()
+		
+		self.position = location
+    }
+    
+	override open func copy(with zone: NSZone? = nil) -> Any {
+        return self
+    }
+}
+
+extension GXGoogleMapsPinMarker {
+	public var forwardAnimator: UIViewPropertyAnimator? {
+		get {
+			return nil
+		}
+		set {
+			return
+		}
+	}
+	
+	public var backwardAnimator: UIViewPropertyAnimator? {
+		get {
+			return nil
+		}
+		set {
+			return
+		}
+	}
+}

--- a/Sources/GXGoogleMaps/GXGoogleMapsView.swift
+++ b/Sources/GXGoogleMaps/GXGoogleMapsView.swift
@@ -1,0 +1,474 @@
+//
+//  GXGoogleMapsView.swift
+//
+
+import GXCoreUI
+internal import GoogleMaps
+private import GoogleMapsUtils
+
+internal class GXGoogleMapsView : GMSMapView, GXMapView {
+	weak var gxMapViewDelegate: GXMapViewDelegate?
+	
+	override open var selectedMarker: GMSMarker? {
+		didSet {
+			if self.selectedMarker != oldValue {
+				if let selectedMarker = self.selectedMarker {
+					self.gxGMSMapViewDelegate?.mapView(self, didSelect: selectedMarker)
+				} else if let oldValue = oldValue {
+					self.gxGMSMapViewDelegate?.mapView(self, didDeselectMarker: oldValue)
+				}
+			}
+		}
+	}
+	
+	var gxMinZoomLevel: NSNumber? {
+		return self.minZoom as NSNumber?
+	}
+	
+	var gxMaxZoomLevel: NSNumber? {
+		return self.maxZoom as NSNumber?
+	}
+	
+	private var shownInfoWindw: MKAnnotationView?
+	private var annotations: [GXGMSMarker] = []
+	internal var overlays: Set<GMSOverlay> = []
+	
+	internal weak var gxGMSMapViewDelegate: GXGMSMapViewDelegate?
+	
+	func gxAnnotations() -> [MKAnnotation] {
+		return annotations as [MKAnnotation]
+	}
+	
+	func gxSelectedAnnotations() -> [MKAnnotation] {
+		[selectedMarker].compactMap { $0  as? GXGMSMarker }
+	}
+	
+	func gxRegionCenter() -> CLLocationCoordinate2D {
+		return self.camera.target
+	}
+	
+	func gxUserLocation() -> CLLocation? {
+		return self.myLocation
+	}
+	
+	func gxLongitudeDelta() -> CLLocationDegrees {
+		return self.coordinateBounds.northEast.longitude - self.coordinateBounds.southWest.longitude
+	}
+	
+	func gxLatitudeDelta() -> CLLocationDegrees {
+		return self.coordinateBounds.northEast.latitude - self.coordinateBounds.southWest.latitude
+	}
+	
+	func gxIsScrollEnabled() -> Bool {
+		return self.settings.allowScrollGesturesDuringRotateOrZoom
+	}
+	
+	private class GXGMUClusterRendererDelegateProxy : NSObject, GMUClusterRendererDelegate {
+		fileprivate func renderer(_ renderer: GMUClusterRenderer, willRenderMarker marker: GMSMarker) {
+			if let marker = marker as? GXGMSMarker, let gxMarker = marker.extractCustomMarkerIfNeeded() {
+				marker.icon = gxMarker.icon
+				marker.iconView = gxMarker.iconView
+			}
+		}
+	}
+	
+	private let _GXGMUClusterRendererDelegateProxy = GXGMUClusterRendererDelegateProxy()
+	
+	internal var clusterMarkers: Bool = false {
+		didSet {
+			if clusterMarkers && clusterManager == nil {
+				let renderer = GMUDefaultClusterRenderer(mapView: self,
+														 clusterIconGenerator: GMUDefaultClusterIconGenerator())
+				renderer.minimumClusterSize = 2 // Match MapKit default behavior
+				renderer.delegate = self._GXGMUClusterRendererDelegateProxy
+				
+				clusterManager = GMUClusterManager(map: self,
+												   algorithm: GMUNonHierarchicalDistanceBasedAlgorithm(),
+												   renderer: renderer)
+				clusterManager?.setMapDelegate(self.delegate)
+			}
+		}
+	}
+	
+	private var clusterManager: GMUClusterManager?
+	
+	func gxAdd(_ annotation: MKAnnotation, isPersistent: Bool) {
+		if let marker = annotation as? GXGMSMarker {
+			annotations.append(marker)
+			marker.appearAnimation = .pop
+			if let iconView = self.gxGMSMapViewDelegate?.mapView(self, iconViewFor: marker) as? GXUC_MapCustomAnnotationView {
+				if (iconView.image == nil || iconView.hasPlaceholderPinImage) {
+					iconView.loadingDelegate = self
+					marker.iconView = iconView
+				} else {
+					self.set(iconView.image!, for: marker)
+				}
+			}
+			
+			if clusterMarkers, let clusterManager {
+				clusterManager.add(marker)
+				clusterManager.requestCluster()
+			} else {
+				DispatchQueue.gxOnMain {
+					marker.map = self
+				}
+			}
+			
+			if isPersistent {
+#if DEBUG
+				assert(marker is GXGoogleMapsMarker)
+#endif
+				(marker as? GXGoogleMapsMarker)?.isPersistent = isPersistent
+			}
+		}
+	}
+	
+	func gxAdd(_ annotations: [MKAnnotation], arePersistent: Bool) {
+		for annotation in annotations {
+			self.gxAdd(annotation, isPersistent: arePersistent)
+		}
+	}
+	
+	func gxAdd(_ overlay: GMSOverlay, isRefreshable: Bool) {
+		if isRefreshable {
+			overlay.isRefreshable = isRefreshable
+		}
+		
+		self.overlays.insert(overlay)
+		
+		DispatchQueue.gxOnMain {
+			overlay.map = self
+		}
+	}
+	
+	func gxRemove(_ annotation: MKAnnotation) {
+		if let annotation = annotation as? GMSMarker {
+			if let clusterManager {
+				clusterManager.remove(annotation)
+				clusterManager.requestCluster()
+			} else {
+				if (annotation.map != nil) {
+					weak var wAnnotation = annotation
+					DispatchQueue.gxOnMain {
+						wAnnotation?.map = nil
+					}
+				}
+			}
+			
+			annotations = annotations.filter { $0 != annotation }
+		}
+	}
+	
+	func gxRemove(_ annotations: [MKAnnotation]) {
+		if let annotations = annotations as? [GXGMSMarker] {
+			for annotation in annotations {
+				self.gxRemove(annotation)
+			}
+		}
+	}
+	
+	func gxShow(_ annotations: [MKAnnotation], animated: Bool) {
+		if let annotations = annotations as? [GXGMSMarker] {
+			let bounds = annotations.reduce(GMSCoordinateBounds()) {
+				$0.includingCoordinate($1.position)
+			}
+			DispatchQueue.gxOnMain {
+				self.updateCamera(newCoordinateBounds: bounds, animated: animated)
+			}
+		}
+	}
+	
+	func gxSelect(_ annotation: MKAnnotation, animated: Bool) {
+		if let annotation = annotation as? GXGMSMarker {
+			if (annotations.contains(annotation)) {
+				DispatchQueue.gxOnMain {
+					self.selectedMarker = annotation
+				}
+			}
+		}
+	}
+	
+	func gxSelectAnnotation(at indexPath: IndexPath, animated: Bool) {
+		if let marker = self.annotations.filter({ (marker) -> Bool in
+			guard let marker = marker as? GXGoogleMapsPinMarker else {
+				return false
+			}
+			return marker.indexPath == indexPath
+		}).first {
+			self.gxSetCenter(marker.coordinate, animated: animated)
+			self.selectedMarker = marker
+		}
+	}
+	
+	func gxDeselect(_ annotation: MKAnnotation?, animated: Bool) {
+		DispatchQueue.gxOnMain {
+			self.selectedMarker = nil
+		}
+	}
+	
+	func gxDeselectAnnotation(at indexPath: IndexPath, animated: Bool) {
+		DispatchQueue.gxOnMain {
+			if let selectedMarker = self.selectedMarker as? GXGoogleMapsPinMarker {
+				if selectedMarker.indexPath == indexPath {
+					self.selectedMarker = nil
+				}
+			}
+		}
+	}
+	
+	func gxSetShowsUserLocation(_ showLocation: Bool) {
+		DispatchQueue.gxOnMain {
+			self.isMyLocationEnabled = showLocation
+			self.settings.myLocationButton = showLocation;
+		}
+	}
+	
+	func gxSetGXMapType(_ gxMapType: GXMapType) {
+		var newMapType: GMSMapViewType!;
+		switch gxMapType {
+		case .hybrid:
+			newMapType = .hybrid
+			
+		case .satellite:
+			newMapType = .satellite
+			
+		default:
+			newMapType = .normal
+		}
+		DispatchQueue.gxOnMain {
+			self.mapType = newMapType
+		}
+	}
+	
+	func gxView(for annotation: MKAnnotation) -> MKAnnotationView? {
+		if let selectedMarker = selectedMarker, let annotation = annotation as? GMSMarker {
+			if annotation == selectedMarker {
+				return shownInfoWindw
+			}
+		}
+		return nil
+	}
+	
+	var gxMapViewCenter: CGPoint {
+		get {
+			var centerPoint = self.projection.point(for: self.camera.target)
+			let insets = self.safeAreaInsets
+			centerPoint.x = centerPoint.x + insets.left / 2 - insets.right / 2
+			centerPoint.y = centerPoint.y + insets.top / 2 - insets.bottom / 2
+			return centerPoint
+		}
+	}
+	
+	func gxSetCenter(_ newCenterCoordinate: CLLocationCoordinate2D, withZoomLevel zoomLevel: Float, animated: Bool) {
+		DispatchQueue.gxOnMain {
+			let newCameraPosition = GMSCameraPosition.camera(withTarget: newCenterCoordinate, zoom: zoomLevel)
+			if (animated) {
+				self.animate(to: newCameraPosition)
+			} else {
+				self.camera = newCameraPosition
+			}
+		}
+	}
+	
+	func gxSetCenter(_ newCenterCoordinate: CLLocationCoordinate2D, animated: Bool) {
+		self.gxSetCenter(newCenterCoordinate, withZoomLevel: self.camera.zoom, animated: animated)
+	}
+	
+	func gxSetZoomLevel(_ zoomLevel: Float, animated: Bool) {
+		self.gxSetCenter(self.gxRegionCenter(), withZoomLevel: zoomLevel, animated: animated)
+	}
+	
+	func gxSetMinZoomLevel(_ minZoomLevel: Float) {
+		self.setMinZoom(minZoomLevel, maxZoom: self.maxZoom)
+	}
+	
+	func gxSetMaxZoomLevel(_ maxZoomLevel: Float) {
+		self.setMinZoom(self.minZoom, maxZoom: maxZoomLevel)
+	}
+	
+	func gxZoomLevel() -> Float {
+		return self.camera.zoom
+	}
+	
+	func gxConvert(_ point: CGPoint, toCoordinateFrom mapView: UIView) -> CLLocationCoordinate2D {
+		let mapPoint = mapView.convert(point, to: mapView)
+		return self.projection.coordinate(for: mapPoint)
+	}
+	
+	func gxVisibleMapRect() -> MKMapRect {
+		let region = self.projection.visibleRegion()
+
+		let x = min(region.nearLeft.latitude, region.farRight.latitude)
+		let y = min(region.nearLeft.longitude, region.farRight.longitude)
+		let width  = abs(region.nearLeft.latitude - region.farRight.latitude)
+		let height = abs(region.nearLeft.longitude - region.farRight.longitude)
+		
+		return MKMapRect.init(x: x, y: y, width: width, height: height)
+	}
+	
+	func gxSetVisibleMapRect(_ mapRect: MKMapRect, edgePadding adjustedMapViewEdgePadding: UIEdgeInsets, animated: Bool) {
+		let northEastPoint = MKMapPoint.init(x: mapRect.maxX, y: mapRect.origin.y)
+		let southWestPoint = MKMapPoint.init(x: mapRect.origin.x, y: mapRect.maxY)
+		
+		let coordinateBounds = GMSCoordinateBounds.init(coordinate: northEastPoint.coordinate,
+														coordinate: southWestPoint.coordinate)
+		
+		self.updateCamera(newCoordinateBounds: coordinateBounds, with: adjustedMapViewEdgePadding, animated: animated)
+	}
+	
+	func gxClearPolylines() {
+		let isUserOverlay: (GMSOverlay) -> Bool = { (overlay) -> Bool in
+			return overlay.isRefreshable
+		}
+		
+		self.overlays
+			.filter { isUserOverlay($0) }
+			.forEach { (overlay) in overlay.map = nil }
+		self.overlays = self.overlays
+			.filter { !isUserOverlay($0) }
+	}
+	
+	func gxClear() { self.gxClear(removeAll: true) }
+	
+	func gxClear(removeAll: Bool) {
+		self.gxRemove(self.annotations)
+		
+		var iterator = self.overlays.makeIterator()
+		while let overlay = iterator.next() {
+			if removeAll || !((overlay as? GXGoogleMapsMarker)?.isPersistent ?? false) {
+				DispatchQueue.gxOnMain {
+					overlay.map = nil
+				}
+				self.overlays.remove(overlay)
+			}
+		}
+	}
+	
+	override var frame: CGRect {
+		didSet { self.gxMapViewDelegate?.didResizeMapView(self) }
+	}
+
+	
+	//MARK: - Internal Helpers
+	
+	private var coordinateBounds: GMSCoordinateBounds {
+		return GMSCoordinateBounds(region: self.projection.visibleRegion())
+	}
+	
+	private func updateCamera(newCoordinateBounds: GMSCoordinateBounds, animated:Bool) {
+		DispatchQueue.gxOnMain {
+			self.updateCamera(newCoordinateBounds: newCoordinateBounds, with: .zero, animated: animated)
+		}
+	}
+	
+	private func updateCamera(newCoordinateBounds: GMSCoordinateBounds, with insets: UIEdgeInsets, animated:Bool) {
+		if let newCameraPosition = self.camera(for: newCoordinateBounds, insets: insets) {
+			let cameraUpdate = GMSCameraUpdate.setCamera(newCameraPosition)
+			
+			DispatchQueue.gxOnMain {
+				if animated {
+					self.animate(with: cameraUpdate)
+				} else {
+					self.moveCamera(cameraUpdate)
+				}
+			}
+		}
+	}
+	
+	fileprivate func set(_ image: UIImage, for marker: GMSMarker) {
+		marker.icon = image
+	}
+}
+
+extension GXGoogleMapsView : GXMapCustomAnnotationViewLoadingDelegate {
+	func didSet(_ image: UIImage, for annotation: MKAnnotation) {
+		if let marker = annotation as? GMSMarker {
+			marker.iconView = nil
+			marker.tracksViewChanges = false
+			self.set(image, for: marker) 
+		}
+	}
+}
+
+private extension GMUClusterManager {
+	private struct Constants {
+		static let CLUSTER_REQUEST_COUNT_IVAR_NAME = "_clusterRequestCount"
+		static let GMU_CLUSTER_WAIT_INTERVAL_SECONDS = 0.2
+	}
+	
+	
+	func requestCluster() {
+		guard var clusterRequestCount = self.value(forKey: Constants.CLUSTER_REQUEST_COUNT_IVAR_NAME) as? UInt else {
+			self.cluster()
+			return
+		}
+		
+		clusterRequestCount += 1
+		self.setValue(clusterRequestCount, forKey: Constants.CLUSTER_REQUEST_COUNT_IVAR_NAME)
+		
+		DispatchQueue.main.asyncAfter(deadline: .now() + Constants.GMU_CLUSTER_WAIT_INTERVAL_SECONDS) { [weak self] in
+			guard let strongSelf = self else { return }
+			guard clusterRequestCount == strongSelf.clusterRequestCount() else { return }
+			
+			strongSelf.cluster()
+		}
+	}
+}
+
+internal class GXGoogleMapsMarker : GXGMSMarker {
+	var isPersistent: Bool {
+		get { gxUserData["isPersistent"] as? Bool ?? false }
+		set { gxUserData["isPersistent"] = newValue }
+	}
+	
+	var clusteringMarker: GXGMSMarker? {
+		get { gxUserData["clusteringMarker"] as? GXGoogleMapsMarker }
+		set { gxUserData["clusteringMarker"] = newValue }
+	}
+	
+	var clusteringMarkerOrSelf: GXGMSMarker {
+		get { clusteringMarker ?? self }
+	}
+	
+	// MARK: - Private
+	
+	private var _gxUserData: [String : Any]!
+	private var gxUserData: [String : Any] {
+		get {
+			if _gxUserData == nil {
+				_gxUserData = [:] as [String : Any]
+			}
+			
+			return _gxUserData
+		}
+		set { _gxUserData = newValue }
+	}
+}
+
+internal extension GMSOverlay {
+	var isRefreshable : Bool {
+		get { gxUserData["isRefreshable"] as? Bool ?? false }
+		set { gxUserData["isRefreshable"] = newValue }
+	}
+	
+	private var gxUserData: [String : Any]! {
+		get {
+			if self.userData == nil {
+				self.userData = [:] as [String : Any]
+			}
+			
+			return self.userData as? [String : Any]
+		}
+		set { self.userData = newValue }
+	}
+}
+
+internal protocol GXGMSMapViewDelegate: NSObjectProtocol {
+	func mapView(_ mapView: GMSMapView, iconViewFor marker: GMSMarker) -> UIView?
+	
+	func mapView(_ mapView: GMSMapView, calloutViewFor marker: GMSMarker) -> UIView?
+	
+	func mapView(_ mapView: GMSMapView, didSelect marker: GMSMarker)
+	
+	func mapView(_ mapView: GMSMapView, didDeselectMarker: GMSMarker)
+}


### PR DESCRIPTION
This PR changes distribution type from binary to sources, enabling dependencies to be migrated from Pods to Swift Packages.

As Google Maps dependencies are distributed as static libraries, using source distribution for this package avoids duplication Google Maps of symbols, which could lead to runtime issues.